### PR TITLE
modif nomcategorie recherche

### DIFF
--- a/src/main/java/fr/miage/agents/api/message/recherche/Rechercher.java
+++ b/src/main/java/fr/miage/agents/api/message/recherche/Rechercher.java
@@ -2,7 +2,6 @@ package fr.miage.agents.api.message.recherche;
 
 import fr.miage.agents.api.message.Message;
 import fr.miage.agents.api.message.TypeMessage;
-import fr.miage.agents.api.model.Categorie;
 
 /**
  * Created by nitix on 14/11/16.
@@ -11,7 +10,7 @@ public class Rechercher extends Message {
 
     public String reference;
 
-    public Categorie categorie;
+    public String nomCategorie;
 
     public String marque;
 


### PR DESCRIPTION
Les clients ne connaissent pas les catégories au départ, ils demandent donc juste grâce au nom de la catégorie.