### PR TITLE
modif relation client supermarche

### DIFF
--- a/src/main/java/fr/miage/agents/api/message/TypeMessage.java
+++ b/src/main/java/fr/miage/agents/api/message/TypeMessage.java
@@ -38,5 +38,9 @@ public enum TypeMessage {
     ReponseEchange,
 
     //Production
-    Production;
+    Production,
+	
+	//Courses
+	AchatClient,
+	ResultatAchatClient;
 }

--- a/src/main/java/fr/miage/agents/api/message/relationclientsupermarche/Achat.java
+++ b/src/main/java/fr/miage/agents/api/message/relationclientsupermarche/Achat.java
@@ -20,6 +20,6 @@ public class Achat extends Message {
 	public UUID Session;
 
 	public Achat() {
-        super(TypeMessage.InitierAchat);
+        super(TypeMessage.AchatClient);
     }
 }

--- a/src/main/java/fr/miage/agents/api/message/relationclientsupermarche/ResultatAchat.java
+++ b/src/main/java/fr/miage/agents/api/message/relationclientsupermarche/ResultatAchat.java
@@ -15,15 +15,13 @@ public class ResultatAchat extends Message{
     public UUID session;
 
     /**
-     * La premiere clé correspond à l'id du produit
-     * La valeur correspond à la map qui contient : 
-     * une clé booléen si l'achat a été effectué ou non
-     * une valeur correspondant à la quantité disponible si à l'achat, 
-     * la quantité demandée dépassait le stock disponible du supermarché
+     * La premiere clé correspond à l'id du produit 
+     * La valeur correspond à la quantité disponible si la quantité demandée était > au stock
+     * ou bien la quantité demandée
      */
-    public Map<Produit,Map<Boolean,Integer>> courses;
+    public Map<Produit,Integer> courses;
 
     public ResultatAchat() {
-        super(TypeMessage.ResultatInitiationAchat);
+        super(TypeMessage.ResultatAchatClient);
     }
 }


### PR DESCRIPTION
Séparation des deux types d'achat (supermarché - client) et (supermarché - fournisseur) -> clarté
Refonte du resultatAchat, booléen inutile et non fonctionnelle..

